### PR TITLE
Default language in translate

### DIFF
--- a/stopcovid/drills/content_loader.py
+++ b/stopcovid/drills/content_loader.py
@@ -1,7 +1,7 @@
 import json
 import os
 import enum
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from jinja2 import Template
 
 
@@ -50,8 +50,8 @@ def template_additional_args(message: str, **kwargs: Any) -> str:
     return result
 
 
-def translate(language: str, template: SupportedTranslation, **kwargs: Any) -> str:
-    value = TRANSLATIONS.get(language, TRANSLATIONS["en"])[template]
+def translate(language: Optional[str], template: SupportedTranslation, **kwargs: Any) -> str:
+    value = TRANSLATIONS.get(language or "en", TRANSLATIONS["en"])[template]
     if kwargs:
         value = template_additional_args(value, **kwargs)
     return value

--- a/stopcovid/sms/enqueue_outbound_sms.py
+++ b/stopcovid/sms/enqueue_outbound_sms.py
@@ -62,7 +62,6 @@ def get_messages_for_event(event: DialogEvent) -> List[OutboundSMS]:  # noqa: C9
         return get_messages(event, event.prompt.messages)
 
     elif isinstance(event, FailedPrompt):
-        assert language
         if not event.abandoned:
             return get_messages(
                 event,
@@ -84,7 +83,6 @@ def get_messages_for_event(event: DialogEvent) -> List[OutboundSMS]:  # noqa: C9
 
     elif isinstance(event, CompletedPrompt):
         if event.prompt.correct_response is not None:
-            assert language
             return get_messages(
                 event,
                 [


### PR DESCRIPTION
We can't guarantee that every user will have a language. Adding a sensible default in the translate method: https://rollbar.com/eslworks/scadmin/items/186/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification