### PR TITLE
Use serverless-datadog-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -438,6 +438,12 @@
         "underscore": "^1.8.3"
       }
     },
+    "serverless-plugin-datadog": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-datadog/-/serverless-plugin-datadog-2.5.0.tgz",
+      "integrity": "sha512-b3r0GWndVJuEDoH+GQfSIl5vGVnOobW/jsuOWY1up1yA48Srtcj6m3ZEEcAxHR6LD+jHoXLBnWPBQfCuFgnDCg==",
+      "dev": true
+    },
     "serverless-python-requirements": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/serverless-python-requirements/-/serverless-python-requirements-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "serverless-dotenv-plugin": "^2.3.2",
     "serverless-log-forwarding": "^1.4.0",
+    "serverless-plugin-datadog": "^2.5.0",
     "serverless-python-requirements": "^5.1.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,8 @@ app: slowcovid
 org: jeffreysilver
 
 custom:
+  datadog:
+    forwarder: ${ssm:/stopcovid/${self:provider.stage}/logForwardingDestinationArn}
   enterprise:
     collectLambdaLogs: false
   logForwarding:
@@ -51,6 +53,7 @@ provider:
 plugins:
   - serverless-python-requirements
   - serverless-log-forwarding
+  - serverless-plugin-datadog
 
 functions:
   twilioWebhook:


### PR DESCRIPTION
Think getting APM working [might be as simple as configuring this plugin](https://docs.datadoghq.com/serverless/installation/python/?tab=serverlessframework), so figured I'd try a quick update. If it works, I'll probably also remove the `serverless-log-fowarding` plugin, as the `serverless-datadog-plugin` should also handle forwarding logs for us.