### PR TITLE
Dont abandon drill instances on dashboard requested

### DIFF
--- a/__tests__/stopcovid/dialog/test_engine.py
+++ b/__tests__/stopcovid/dialog/test_engine.py
@@ -520,9 +520,8 @@ class TestProcessCommand(unittest.TestCase):
             self.assertIsNone(self.dialog_state.current_drill)
             self.assertIsNone(self.dialog_state.drill_instance_id)
             self.assertIsNone(self.dialog_state.current_prompt_state)
-            self.assertEqual(
+            self.assertIsNone(
                 batch.events[0].abandoned_drill_instance_id,
-                uuid.UUID("11111111-1111-1111-1111-111111111111"),
             )
 
     def test_support_requested(self):

--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -278,11 +278,7 @@ class ProcessSMSMessage(Command):
         self, dialog_state: DialogState, base_args: Dict[str, Any]
     ) -> Optional[List[DialogEvent]]:
         if self.content_lower in ["dashboard", "tablero"]:
-            return [
-                DashboardRequested(
-                    **base_args, abandoned_drill_instance_id=dialog_state.drill_instance_id
-                )
-            ]
+            return [DashboardRequested(**base_args)]
         return None
 
     def _update_schedule_requested(


### PR DESCRIPTION
![Image from iOS (1)](https://user-images.githubusercontent.com/12646851/99433718-e03d6180-28db-11eb-949f-2bcbfca690af.png)
this screenshot convinced me that abandoning drill instances is the wrong behavior here