### PR TITLE
Add failiure queue to publish dialog event batches

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -149,6 +149,14 @@ functions:
               - DialogEventBatches
               - StreamArn
           startingPosition: LATEST
+          maximumRetryAttempts: 5
+          destinations:
+            onFailure:
+              arn:
+                Fn::GetAtt:
+                  - PublishDialogEventBatchesFailureQueue
+                  - Arn
+              type: sqs
 
 resources:
   Resources:
@@ -318,3 +326,8 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: distribute-dialog-events-failures-${self:provider.stage}
+
+    PublishDialogEventBatchesFailureQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: publish-dialog-events-batches-failures-${self:provider.stage}


### PR DESCRIPTION
put records to kinesis is failing intermittently. we're currently dropping these events. we have them in rollbar so ill figure out how to replay them