### PR TITLE
Enable new and old images in dynamodb streams

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -264,7 +264,7 @@ resources:
             Projection:
               ProjectionType: ALL
         StreamSpecification:
-          StreamViewType: NEW_IMAGE
+          StreamViewType: NEW_AND_OLD_IMAGES
         BillingMode: PAY_PER_REQUEST
 
     # GENERAL IDEMPOTENCY


### PR DESCRIPTION
This is required in order to let fivetran read from dynamodb. It's also required to enabled "Global DynamoDB tables" which automatically copy a table from one region to another. 

My plan is to:
- deploy this
- enable global table that copies dialog-event-batches-prod to us-east-2
- only give fivetran access to dynamodb in us-east-2


Deploying this _should_ be fine because of this: https://github.com/opus-training/dialog-engine/blob/master/stopcovid/dialog/aws_lambdas/publish_dialog_event_batches.py#L21-L23