### PR TITLE
dont abandon drills on menu requested

### DIFF
--- a/__tests__/stopcovid/dialog/models/test_events.py
+++ b/__tests__/stopcovid/dialog/models/test_events.py
@@ -540,15 +540,10 @@ class TestSerialization(unittest.TestCase):
         original = MenuRequested(
             phone_number="123456789",
             user_profile=UserProfile(validated=True),
-            abandoned_drill_instance_id="11111111-1111-1111-1111-111111111111",
         )
         serialized = original.dict()
         deserialized = event_from_dict(serialized)
         self._make_base_assertions(original, deserialized)
-        self.assertEqual(
-            deserialized.abandoned_drill_instance_id,
-            uuid.UUID("11111111-1111-1111-1111-111111111111"),
-        )
 
     def test_unhandled_message_received(self):
         original = UnhandledMessageReceived(

--- a/__tests__/stopcovid/dialog/test_engine.py
+++ b/__tests__/stopcovid/dialog/test_engine.py
@@ -566,13 +566,6 @@ class TestProcessCommand(unittest.TestCase):
             command = ProcessSMSMessage(self.phone_number, message)
             batch = self._process_command(command)
             self._assert_event_types(batch, DialogEventType.MENU_REQUESTED)
-            self.assertIsNone(self.dialog_state.current_drill)
-            self.assertIsNone(self.dialog_state.drill_instance_id)
-            self.assertIsNone(self.dialog_state.current_prompt_state)
-            self.assertEqual(
-                batch.events[0].abandoned_drill_instance_id,
-                uuid.UUID("11111111-1111-1111-1111-111111111111"),
-            )
 
     def test_unhandled_message_received(self):
         self.dialog_state.user_profile.validated = True

--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -339,11 +339,7 @@ class ProcessSMSMessage(Command):
         self, dialog_state: DialogState, base_args: Dict[str, Any]
     ) -> Optional[List[DialogEvent]]:
         if self.content_lower in ["menu", "menú"]:
-            return [
-                MenuRequested(
-                    **base_args, abandoned_drill_instance_id=dialog_state.drill_instance_id
-                )
-            ]
+            return [MenuRequested(**base_args)]
         return None
 
     def _unhandled_message(

--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -239,9 +239,6 @@ class MenuRequested(DialogEvent):
     abandoned_drill_instance_id: Optional[uuid.UUID] = None
 
     def apply_to(self, dialog_state: DialogState) -> None:
-        dialog_state.current_drill = None
-        dialog_state.drill_instance_id = None
-        dialog_state.current_prompt_state = None
         dialog_state.user_profile.opted_out = False
 
 


### PR DESCRIPTION
We had a user text menu and then try to continue his lesson. He got confused. There's no need to null out the drill state in this case. When they actually do a menu command we will override it with the config lesson