### PR TITLE
Add user_profile to dialog event batch

### DIFF
--- a/__tests__/stopcovid/dialog/test_engine.py
+++ b/__tests__/stopcovid/dialog/test_engine.py
@@ -329,7 +329,7 @@ class TestProcessCommand(unittest.TestCase):
         self.dialog_state.user_profile.validated = True
         self.dialog_state.current_drill = choose_language_drill
         self._set_current_prompt(0, drill=choose_language_drill)
-        command = ProcessSMSMessage(self.phone_number, "en")
+        command = ProcessSMSMessage(self.phone_number, "es")
         batch = self._process_command(command)
 
         self._assert_event_types(
@@ -337,7 +337,8 @@ class TestProcessCommand(unittest.TestCase):
             DialogEventType.COMPLETED_PROMPT,
             DialogEventType.DRILL_COMPLETED,
         )
-        self.assertEqual(batch.events[0].user_profile_updates, {"language": "en"})
+        self.assertEqual(batch.events[0].user_profile_updates, {"language": "es"})
+        self.assertEqual(batch.user_profile.language, "es")
 
     @patch("stopcovid.drills.drills.Prompt.should_advance_with_answer", return_value=False)
     def test_conclude_with_too_many_wrong_answers(self, *args):

--- a/simulator.py
+++ b/simulator.py
@@ -83,7 +83,6 @@ class InMemoryRepository(DialogRepository):
         self.repo[dialog_state.phone_number] = dialog_state.json()
         assert dialog_state.user_profile.language
         drill_to_start = None
-        print(event_batch.user_profile)
         for event in event_batch.events:
             if isinstance(event, AdvancedToNextPrompt):
                 fake_sms(

--- a/simulator.py
+++ b/simulator.py
@@ -83,6 +83,7 @@ class InMemoryRepository(DialogRepository):
         self.repo[dialog_state.phone_number] = dialog_state.json()
         assert dialog_state.user_profile.language
         drill_to_start = None
+        print(event_batch.user_profile)
         for event in event_batch.events:
             if isinstance(event, AdvancedToNextPrompt):
                 fake_sms(

--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -80,7 +80,12 @@ def process_command(command: Command, seq: str, repo: DialogRepository = None) -
         event.user_profile.account_info = end_account_info
     dialog_state.seq = seq
     repo.persist_dialog_state(
-        DialogEventBatch(events=events, phone_number=command.phone_number, seq=seq),
+        DialogEventBatch(
+            events=events,
+            phone_number=command.phone_number,
+            seq=seq,
+            user_profile=dialog_state.user_profile,
+        ),
         dialog_state,
     )
 

--- a/stopcovid/dialog/models/events.py
+++ b/stopcovid/dialog/models/events.py
@@ -295,6 +295,7 @@ class DialogEventBatch(pydantic.BaseModel):
     seq: str
     batch_id: uuid.UUID = pydantic.Field(default_factory=uuid.uuid4)
     created_time: datetime = pydantic.Field(default_factory=lambda: datetime.now(UTC))
+    user_profile: Optional[UserProfile] = None
 
 
 def batch_from_dict(batch_dict: Dict[str, Any]) -> DialogEventBatch:

--- a/stopcovid/dialog/models/state.py
+++ b/stopcovid/dialog/models/state.py
@@ -35,9 +35,6 @@ class UserProfile(pydantic.BaseModel):
     ssl_opt_in: Optional[str] = None
     is_working: Optional[str] = None
 
-    def __str__(self) -> str:
-        return f"lang={self.language}, validated={self.validated}, " f"name={self.name}"
-
     @pydantic.validator("language", pre=True, always=True)
     def set_language(cls, value: Optional[str]) -> Optional[str]:
         if value is not None:


### PR DESCRIPTION
Each event reflects the state of the user profile *before* the event was applied. The DialogEventBatch will also now carry with it the resulting user_profile after each event is applied