### PR TITLE
Add unresolvedVariablesNotificationMode and ssm:GetParameter

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,6 +2,8 @@ service: slowcovid
 app: slowcovid
 org: jeffreysilver
 
+unresolvedVariablesNotificationMode: error
+
 custom:
   datadog:
     forwarder: ${ssm:/stopcovid/${self:provider.stage}/datadogForwarderArn}
@@ -34,6 +36,7 @@ provider:
         - secretsmanager:GetSecretValue
         - s3:GetObject
         - s3:GetObjectVersion
+        - ssm:GetParameter
       Resource: "*"
 
   environment:


### PR DESCRIPTION
- unresolvedVariablesNotificationMode will make it so the deploy fails if it cant read a variable
- leading theory is that we arent giving the iam role access to ssm