### PR TITLE
Fix bug in response_check

### DIFF
--- a/__tests__/stopcovid/drills/test_response_check.py
+++ b/__tests__/stopcovid/drills/test_response_check.py
@@ -18,6 +18,7 @@ SAMPLES = [
     ["She uses a knife", "d) uses / mandolin", False],
     ["2-3 pumps", "b) 2-3 pumps", True],
     ["1 pump", "b) 2-3 pumps", False],
+    ["a water proof bandage", "a. first aid kit", False],
 ]
 
 

--- a/stopcovid/drills/response_check.py
+++ b/stopcovid/drills/response_check.py
@@ -26,8 +26,12 @@ def is_correct_response(user_response: str, correct_response: str) -> bool:
         or 1
     )
 
-    # if first token is a single letter and matches, user is correct
-    if re.match(r"^[a-zA-Z]$", clean_user_response[0]) and len(clean_correct_response[0]) == 1:
+    # if user responds a single letter and it matches, user is correct
+    if (
+        len(clean_user_response) == 1
+        and re.match(r"^[a-zA-Z]$", clean_user_response[0])
+        and len(clean_correct_response[0]) == 1
+    ):
         return clean_user_response[0] == clean_correct_response[0]
 
     # If answer includes "yes", accept "si" and vice versa


### PR DESCRIPTION
We've seen a few users respond to a question like:

> What do you put on a cut finger?
a. a hairnet
b. an apron
c. a finger cot

With: `a finger cot`

The previous implementation picked up `a finger cot` as `a`, and told the user they were wrong