### PR TITLE
unblock demo system test

### DIFF
--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -159,6 +159,7 @@ class ProcessSMSMessage(Command):
             self._handle_opt_out,
             self._handle_opt_back_in,
             self._validate_demo_registration,
+            self._demo_user_demo_requested,
             self._check_response,
             self._demo_requested,
             self._validate_registration,
@@ -219,6 +220,14 @@ class ProcessSMSMessage(Command):
                 return [UserValidated(code_validation_payload=validation_payload, **base_args)]
             if not dialog_state.user_profile.validated:
                 return [UserValidationFailed(**base_args)]
+        return None
+
+    # let the system test user text "opus" to restart the demo without finishing it
+    def _demo_user_demo_requested(
+        self, dialog_state: DialogState, base_args: Dict[str, Any]
+    ) -> Optional[List[DialogEvent]]:
+        if dialog_state.user_profile.is_demo and self.content_lower == "opus":
+            return [DemoRequested(**base_args)]
         return None
 
     def _demo_requested(

--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -159,9 +159,8 @@ class ProcessSMSMessage(Command):
             self._handle_opt_out,
             self._handle_opt_back_in,
             self._validate_demo_registration,
-            self._demo_user_demo_requested,
-            self._check_response,
             self._demo_requested,
+            self._check_response,
             self._validate_registration,
             self._drill_requested,
             self._next_drill_requested,
@@ -220,14 +219,6 @@ class ProcessSMSMessage(Command):
                 return [UserValidated(code_validation_payload=validation_payload, **base_args)]
             if not dialog_state.user_profile.validated:
                 return [UserValidationFailed(**base_args)]
-        return None
-
-    # let the system test user text "opus" to restart the demo without finishing it
-    def _demo_user_demo_requested(
-        self, dialog_state: DialogState, base_args: Dict[str, Any]
-    ) -> Optional[List[DialogEvent]]:
-        if dialog_state.user_profile.is_demo and self.content_lower == "opus":
-            return [DemoRequested(**base_args)]
         return None
 
     def _demo_requested(


### PR DESCRIPTION
~this isn't ideal, but it's fine for now. we need the system test user to be able to retrigger the demo while in the middle of a drill, while non demo users should only be able to trigger the demo _outside_ of a drill~

we'll get alerted in slack if someone gets confused and somehow texts opus unintentionally 