### PR TITLE
Don't send messages with null content

### DIFF
--- a/stopcovid/sms/send_sms.py
+++ b/stopcovid/sms/send_sms.py
@@ -50,6 +50,8 @@ def _send_batch(batch: SMSBatch) -> Optional[List[MessageInstance]]:
         return None
     twilio_responses = []
     for i, message in enumerate(batch.messages):
+        if (message.body is None) and (message.media_url is None):
+            continue
         res = twilio.send_message(batch.phone_number, message.body, message.media_url)
         _publish_send(res, message.media_url)
         twilio_responses.append(res)

--- a/stopcovid/sms/send_sms.py
+++ b/stopcovid/sms/send_sms.py
@@ -51,6 +51,7 @@ def _send_batch(batch: SMSBatch) -> Optional[List[MessageInstance]]:
     twilio_responses = []
     for i, message in enumerate(batch.messages):
         if (message.body is None) and (message.media_url is None):
+            logging.info(f"Skipped messages to {batch.phone_number}; no body or media_url")
             continue
         res = twilio.send_message(batch.phone_number, message.body, message.media_url)
         _publish_send(res, message.media_url)


### PR DESCRIPTION
In response to some unsent messages currently in the SQS DLQ

The Twilio API errors if we try to send messages with neither a message body nor a media URL: https://app.datadoghq.com/logs?cols=core_host%2Ccore_service&event=AQAAAXk9bRC9YiQQMQAAAABBWGs5YlRQUUFBREszc24yR0pKWWJBQUU&from_ts=1620233228400&index=%2A&live=false&messageDisplay=inline&query=service%3Aslowcovid-prod-sendmessage&stream_sort=desc&to_ts=1620233228500

And rising tide has a custom course with a lesson with a true/false question with an intro message that just has a newline in it: https://dashboard.opus.so/courses/333/lesson/2611
I haven't followed the data downstream, but my assumption is that we strip whitespace from that message at some point, but because it technically had content, still treat it as a message we need to send