### PR TITLE
Revert "temporarily disable stale drill check"

### DIFF
--- a/__tests__/stopcovid/dialog/test_engine.py
+++ b/__tests__/stopcovid/dialog/test_engine.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 from typing import Optional
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from pytz import UTC
 
 from stopcovid.dialog.engine import (
@@ -482,28 +482,28 @@ class TestProcessCommand(unittest.TestCase):
         batch = self._process_command(command)
         self._assert_event_types(batch, DialogEventType.DRILL_REQUESTED)
 
-    # def test_ask_for_drill_on_stale_drill(self):
-    #     self.dialog_state.user_profile.validated = True
-    #     self.dialog_state.user_profile.account_info = AccountInfo(employer_id=1)
-    #     self.dialog_state.current_drill = self.drill
-    #
-    #     # texting go while you have an old drill emits a DRILL_REQUESTED event
-    #     self.dialog_state.current_prompt_state = PromptState(
-    #         slug=self.drill.prompts[0].slug, start_time=self.now - timedelta(hours=40)
-    #     )
-    #     command = ProcessSMSMessage(self.phone_number, "go")
-    #     batch = self._process_command(command)
-    #     self._assert_event_types(batch, DialogEventType.DRILL_REQUESTED)
-    #
-    #     # but if you have a drill you recently interacted with, go is treated as a response
-    #     self.dialog_state.current_prompt_state = PromptState(
-    #         slug=self.drill.prompts[0].slug, start_time=self.now - timedelta(minutes=1)
-    #     )
-    #     command = ProcessSMSMessage(self.phone_number, "go")
-    #     batch = self._process_command(command)
-    #     self._assert_event_types(
-    #         batch, DialogEventType.COMPLETED_PROMPT, DialogEventType.ADVANCED_TO_NEXT_PROMPT
-    #     )
+    def test_ask_for_drill_on_stale_drill(self):
+        self.dialog_state.user_profile.validated = True
+        self.dialog_state.user_profile.account_info = AccountInfo(employer_id=1)
+        self.dialog_state.current_drill = self.drill
+
+        # texting go while you have an old drill emits a DRILL_REQUESTED event
+        self.dialog_state.current_prompt_state = PromptState(
+            slug=self.drill.prompts[0].slug, start_time=self.now - timedelta(hours=40)
+        )
+        command = ProcessSMSMessage(self.phone_number, "go")
+        batch = self._process_command(command)
+        self._assert_event_types(batch, DialogEventType.DRILL_REQUESTED)
+
+        # but if you have a drill you recently interacted with, go is treated as a response
+        self.dialog_state.current_prompt_state = PromptState(
+            slug=self.drill.prompts[0].slug, start_time=self.now - timedelta(minutes=1)
+        )
+        command = ProcessSMSMessage(self.phone_number, "go")
+        batch = self._process_command(command)
+        self._assert_event_types(
+            batch, DialogEventType.COMPLETED_PROMPT, DialogEventType.ADVANCED_TO_NEXT_PROMPT
+        )
 
     def test_send_ad_hoc_message(self):
         self.dialog_state.user_profile.validated = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,7 @@ pip-tools
 black==20.8b0
 flake8
 mypy
+
+types-requests
+types-pytz
+types-jinja2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,3 @@ pip-tools
 black==20.8b0
 flake8
 mypy
-
-types-requests
-types-pytz
-types-jinja2

--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -304,7 +304,7 @@ class ProcessSMSMessage(Command):
     def _drill_requested(
         self, dialog_state: DialogState, base_args: Dict[str, Any]
     ) -> Optional[List[DialogEvent]]:
-        if not dialog_state.current_drill:  # or self._current_drill_is_stale(dialog_state):
+        if not dialog_state.current_drill or self._current_drill_is_stale(dialog_state):
             if self.content_lower in [
                 "go",
                 "vamos",


### PR DESCRIPTION
Reverts opus-training/dialog-engine#131

now that I've fixed registration in scadmin we can re-enable the stale-drill check