### PR TITLE
Add sms_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,15 @@ localstack start --host
 - When restarting localstack in host mode, Kinesis/DynamoDB will sometimes end up in a corrupted state and/or fail to shut down, leaving lingering processes & blocked ports. Usually, manually stopping any `java` or `kinesis-*` processes will fix this, or removing the localstack `infra` directory (more details in [this GitHub issue](https://github.com/localstack/localstack/issues/514))
 - At time of writing, [localstack Kinesis directly invokes Lambda functions (if they are linked to a stream) before returning a response to PUT record requests](https://github.com/localstack/localstack/issues/4354). If there are errors in the lambda invocation, this can result in confusing "timeouts" in the client PUTing records to Kinesis
 - The `start` npm script should work in theory, but is currently broken in practice: Cloudformation updates in localstack "fail" to deploy our lambdas (even though they successfully provision), so the `deploy` script always has an exit code of 1
+
+## SMS Client
+
+After deploying `dialog-engine` to localstack, `sms_client.py` allows for direct interaction with `dialog-engine` as if actually sending & receiving SMS from a client application. Example steps:
+
+1. Start the `api`, `dbq_consumer`, and `dialog_event_consumer` docker-compose services in `scadmin`
+
+2. Start the client, e.g.: `python sms_client.py http://localhost:4566 +15552345678`
+
+3. Invite an employee at the same phone from step 2 using a locally running `dashboard` instance
+
+4. You should receive an invitation in your step 2 shell; send a message back

--- a/manage.py
+++ b/manage.py
@@ -12,15 +12,6 @@ from stopcovid.utils.boto3 import get_boto3_client, get_boto3_resource
 configure_logging()
 
 
-def get_env(stage: str) -> Dict[str, str]:
-    filename = {"dev": ".env.development", "prod": ".env.production"}[stage]
-    with open(filename) as file:
-        return {
-            line_part[0].strip(): line_part[1].strip()
-            for line_part in (line.split("=") for line in file.readlines())
-        }
-
-
 def handle_redrive_sqs(args: Any) -> None:
     sqs = get_boto3_resource("sqs")
 

--- a/sms_client.py
+++ b/sms_client.py
@@ -1,0 +1,73 @@
+import argparse
+from threading import Thread
+import json
+import os
+
+from stopcovid.utils.boto3 import get_boto3_client
+from stopcovid.dialog.command_stream.publish import CommandPublisher
+
+
+GREEN = "\033[92m"
+END_COLOR = "\033[0m"
+QUEUE_URL_PATH = "/000000000000/outbound-sms-dlq-local.fifo"
+
+
+parser = argparse.ArgumentParser(
+    description="Simulate a text message client via localstack",
+    epilog="Example use: `python sms_client.py http://localhost:4566 +15552345678`",
+)
+parser.add_argument("localstack", type=str, help="Host of running localstack instance")
+parser.add_argument("phone", type=str, help="Phone number to send & receive messages from")
+
+
+def read_messages(phone: str, localstack: str) -> None:
+    sqs = get_boto3_client("sqs")
+    queue_url = f"{localstack}{QUEUE_URL_PATH}"
+    while True:
+        res = sqs.receive_message(QueueUrl=queue_url)
+        messages = res.get("Messages")
+        if messages:
+            for message in messages:
+                body = json.loads(message["Body"])
+                phone_number = body["phone_number"]
+                if phone_number == phone:
+                    print(GREEN)
+                    print(f"Inbound to {phone_number}:")
+                    for m in body["messages"]:
+                        print(m["body"])
+                        if m["media_url"]:
+                            print(m["media_url"])
+                    print(END_COLOR)
+                    sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"])
+
+
+def send_messages(phone: str) -> None:
+    while True:
+        message = input(f"Send a message as {phone}:\n")
+        print(GREEN)
+        print(f"Outbound from {phone}:")
+        print(message)
+        print(END_COLOR)
+        CommandPublisher().publish_process_sms_command(phone, message, {})
+
+
+def main() -> None:
+    args = parser.parse_args()
+    if os.environ.get("STAGE") != "local":
+        print("Not local environment; exiting")
+        return
+    thread_1 = Thread(
+        target=read_messages,
+        args=(
+            args.phone,
+            args.localstack,
+        ),
+    )
+    thread_2 = Thread(target=send_messages, args=(args.phone,))
+    thread_1.start()
+    thread_2.start()
+    thread_2.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/stopcovid/sms/send_sms.py
+++ b/stopcovid/sms/send_sms.py
@@ -19,6 +19,10 @@ IDEMPOTENCY_REALM = "send-sms"
 IDEMPOTENCY_EXPIRATION_MINUTES = 24 * 60  # one day
 
 
+class LocalEnvironmentException(Exception):
+    pass
+
+
 def _publish_send(twilio_response: twilio.TwilioResponse, media_url: Optional[str] = None) -> None:
     try:
         publish.publish_outbound_sms(
@@ -44,7 +48,8 @@ def _publish_send(twilio_response: twilio.TwilioResponse, media_url: Optional[st
 
 def _send_batch(batch: SMSBatch) -> Optional[List[twilio.TwilioResponse]]:
     if os.environ.get("STAGE") == "local":
-        logging.info(f"Local environment; skipping Twilio send: {batch}")
+        logging.info(f"Local environment; raising: {batch}")
+        raise LocalEnvironmentException
         return None
     if is_fake_phone_number(batch.phone_number):
         logging.info(f"Abandoning batch to fake phone number: {batch.phone_number}")

--- a/stopcovid/sms/send_sms.py
+++ b/stopcovid/sms/send_sms.py
@@ -48,9 +48,8 @@ def _publish_send(twilio_response: twilio.TwilioResponse, media_url: Optional[st
 
 def _send_batch(batch: SMSBatch) -> Optional[List[twilio.TwilioResponse]]:
     if os.environ.get("STAGE") == "local":
-        logging.info(f"Local environment; raising: {batch}")
+        logging.info(f"Local environment; raising to send to DLQ: {batch}")
         raise LocalEnvironmentException
-        return None
     if is_fake_phone_number(batch.phone_number):
         logging.info(f"Abandoning batch to fake phone number: {batch.phone_number}")
         return None


### PR DESCRIPTION
This works by raising exceptions in the `outbound-sms` queue handler so all messages that we'd send out to Twilio in dev/prod go the DLQ in local. The client then processes the DLQ messages

The cleaner/more ideal way to do this would be to provision an additional queue just for the client, and then publish to it from the `outbound-sms` handler. However, I can't find a straightforward way to provision resources selectively per environment in the `serverless` config (as we'd only want to provision this specialized queue in `local`), so making do with the existing infrastructure