### PR TITLE
Add "next" to drill requested words

### DIFF
--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -309,6 +309,7 @@ class ProcessSMSMessage(Command):
         if not dialog_state.current_drill or self._current_drill_is_stale(dialog_state):
             if self.content_lower in [
                 "go",
+                "next",
                 "vamos",
                 "start",
                 "comienzo",


### PR DESCRIPTION
Been seeing some users text "next" instead of "go" to get their next lesson (and we have [some course content](https://dashboard.opus.so/courses/854) that suggests users do this)