### PR TITLE
Remove stale lesson check

### DIFF
--- a/__tests__/stopcovid/dialog/test_engine.py
+++ b/__tests__/stopcovid/dialog/test_engine.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 from typing import Optional
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 from pytz import UTC
 
 from stopcovid.dialog.engine import (
@@ -493,29 +493,6 @@ class TestProcessCommand(unittest.TestCase):
         command = ProcessSMSMessage(self.phone_number, "esl")
         batch = self._process_command(command)
         self._assert_event_types(batch, DialogEventType.ENGLISH_LESSON_DRILL_REQUESTED)
-
-    def test_ask_for_drill_on_stale_drill(self):
-        self.dialog_state.user_profile.validated = True
-        self.dialog_state.user_profile.account_info = AccountInfo(employer_id=1)
-        self.dialog_state.current_drill = self.drill
-
-        # texting go while you have an old drill emits a DRILL_REQUESTED event
-        self.dialog_state.current_prompt_state = PromptState(
-            slug=self.drill.prompts[0].slug, start_time=self.now - timedelta(hours=40)
-        )
-        command = ProcessSMSMessage(self.phone_number, "go")
-        batch = self._process_command(command)
-        self._assert_event_types(batch, DialogEventType.DRILL_REQUESTED)
-
-        # but if you have a drill you recently interacted with, go is treated as a response
-        self.dialog_state.current_prompt_state = PromptState(
-            slug=self.drill.prompts[0].slug, start_time=self.now - timedelta(minutes=1)
-        )
-        command = ProcessSMSMessage(self.phone_number, "go")
-        batch = self._process_command(command)
-        self._assert_event_types(
-            batch, DialogEventType.COMPLETED_PROMPT, DialogEventType.ADVANCED_TO_NEXT_PROMPT
-        )
 
     def test_send_ad_hoc_message(self):
         self.dialog_state.user_profile.validated = True

--- a/stopcovid/dialog/engine.py
+++ b/stopcovid/dialog/engine.py
@@ -3,8 +3,6 @@ import uuid
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import List, Optional, Dict, Any, Callable
-from datetime import datetime, timedelta
-from pytz import UTC
 
 import stopcovid.dialog.models.events
 from stopcovid.dialog.models.events import (
@@ -306,7 +304,7 @@ class ProcessSMSMessage(Command):
     def _drill_requested(
         self, dialog_state: DialogState, base_args: Dict[str, Any]
     ) -> Optional[List[DialogEvent]]:
-        if not dialog_state.current_drill or self._current_drill_is_stale(dialog_state):
+        if not dialog_state.current_drill:
             if self.content_lower in [
                 "go",
                 "next",
@@ -323,20 +321,13 @@ class ProcessSMSMessage(Command):
     def _english_lesson_drill_requested(
         self, dialog_state: DialogState, base_args: Dict[str, Any]
     ) -> Optional[List[DialogEvent]]:
-        if not dialog_state.current_drill or self._current_drill_is_stale(dialog_state):
+        if not dialog_state.current_drill:
             if self.content_lower in [
                 "english",
                 "esl",
             ]:
                 return [EnglishLessonDrillRequested(**base_args)]
         return None
-
-    def _current_drill_is_stale(self, dialog_state: DialogState) -> bool:
-        if not dialog_state.current_prompt_state:
-            return True
-        return datetime.now(UTC) - dialog_state.current_prompt_state.start_time > timedelta(
-            minutes=DRILL_REQUESTED_OVERRIDE_CURRENT_DRILL_MINUTES
-        )
 
     def _next_drill_requested(
         self, dialog_state: DialogState, base_args: Dict[str, Any]


### PR DESCRIPTION
Rachael's demo got messed up because it was a few hours stale and the prompt asked her to text GO. We originally introduced this logic to make it so you could text GO to get out of a CSAT drill. We removed CSAT surveys, so I think this logic is now just unnecessary complexity