### PR TITLE
add messaging_service_sid to enqueue outbound sms payload

### DIFF
--- a/stopcovid/sms/enqueue_outbound_sms.py
+++ b/stopcovid/sms/enqueue_outbound_sms.py
@@ -37,8 +37,8 @@ class OutboundSMS:
     event_id: uuid.UUID
     phone_number: str
     body: Optional[str]
-    messaging_service_sid: Optional[str] = None
     media_url: Optional[str] = None
+    messaging_service_sid: Optional[str] = None
 
 
 def get_messages(
@@ -162,6 +162,7 @@ def publish_outbound_sms_messages(outbound_sms_messages: List[OutboundSMS]) -> A
                 "MessageBody": json.dumps(
                     {
                         "phone_number": phone,
+                        "messaging_service_sid": messages[0].messaging_service_sid,
                         "messages": [
                             {"body": message.body, "media_url": message.media_url}
                             for message in messages


### PR DESCRIPTION
Missed this in my first PR to get customer specific messaging services working. This is a little strange -- we have a flat list of messages, and then turn them into "batches" per phone number. If I were to refactor this I'd introduce the "message batch" concept a little higher up, but that's out of scope for now